### PR TITLE
Defensive python SDK registration and assignment on 2026.2 platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Fixed Python SDK registration and project assignment on the `2026.2` platform.
+
 ### Removed
 
 ## [1.9.1] - 2026-08-12

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ import:
   - module: "python-data-science-samples.jupyter-notebook"
     path: "C:/PYTHON/Miniconda3-py312_24.1.2-0/envs/python-3.9.1/python.exe"
     type: "PYTHON"
+  - module: "project-with-local-venv"
+    path: "$PROJECT_DIR$"
+    type: "PYTHON"
   - module: "python-data-science-samples.java-samples"
     path: "C:\\JAVA\\.gradle\\jdks\\adoptium-18-x64-hotspot-windows"
     type: "JAVA"
@@ -34,9 +37,11 @@ import:
 
 Where:
 
-* `module` should match the Intellij's module name. Nested modules are separated with `.`. For the module name matching
-  project name SDK will be also added to the Project,
-* `path` is the location of SDK on files system,
+* `module` should match the Intellij's module name. Nested modules are separated with `.`. A Java SDK is also assigned
+  to the project when the module name matches the project name. A Python SDK is also assigned to the project when the
+  selected module has the project base directory as one of its content roots,
+* `path` is the location of SDK on files system. For Python, it may point to the interpreter executable,
+  the virtual environment directory, or a project directory containing a `.venv` virtual environment,
 * `type` should be one of the supported SDKs enumerate values,
 * `$PROJECT_DIR$` is a main project base directory which will be translated into a full proper path,
 

--- a/src/main/kotlin/com/pswidersk/sdkimportplugin/python/PythonSdkProcessor.kt
+++ b/src/main/kotlin/com/pswidersk/sdkimportplugin/python/PythonSdkProcessor.kt
@@ -1,62 +1,143 @@
 package com.pswidersk.sdkimportplugin.python
 
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
 import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.jetbrains.python.projectCreation.createVenvAndSdk
-import com.jetbrains.python.sdk.ModuleOrProject
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.jetbrains.python.sdk.PythonSdkType
 import com.jetbrains.python.sdk.pythonSdk
 import com.pswidersk.sdkimportplugin.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.jdom.Element
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+
+private val pythonSdkRegistrationMutex = Mutex()
 
 class PythonSdkProcessor(private val cs: CoroutineScope) : SdkProcessor {
 
     override fun applySdk(project: Project, sdkConfig: SdkImportConfigEntry) {
         if (sdkConfig.type == PYTHON_SDK_TYPE) {
-            cs.launch {
-                addPythonSdk(project, sdkConfig)
+            project.withModule(sdkConfig.module) { module ->
+                cs.launch {
+                    try {
+                        addPythonSdk(project, module, sdkConfig)
+                    } catch (exception: CancellationException) {
+                        throw exception
+                    } catch (exception: Exception) {
+                        errorNotif(project, exception)
+                    }
+                }
             }
         }
     }
 
-    private suspend fun addPythonSdk(project: Project, sdkConfig: SdkImportConfigEntry) {
-        val sdkHome = sdkConfig.loadSdkFile(project)
-        val sdkTable = ProjectJdkTable.getInstance()
-        val pythonSdkName = "Python env: ${sdkConfig.path}"
-        val tableSdk = sdkTable.findJdk(pythonSdkName)
+    internal suspend fun addPythonSdk(project: Project, module: Module, sdkConfig: SdkImportConfigEntry) {
+        val configuredPath = sdkConfig.loadSdkFile(project).toNioPath()
+        val pythonSdkName = "Python env: $configuredPath"
+        val pythonExecutable = resolvePythonExecutable(configuredPath)
+        val sdkHome = writeAction {
+            LocalFileSystem.getInstance().refreshAndFindFileByNioFile(pythonExecutable)
+        } ?: throw IllegalArgumentException("Python executable can not be loaded: `$pythonExecutable`")
+        val (sdk, created) = pythonSdkRegistrationMutex.withLock {
+            withContext(Dispatchers.EDT) {
+                val sdkTable = ProjectJdkTable.getInstance()
+                val pythonSdkType = PythonSdkType.getInstance()
+                val registeredSdk = findRegisteredPythonSdk(
+                    pythonExecutable,
+                    sdkTable.allJdks.filter { it.sdkType == pythonSdkType },
+                )
 
-        val sdk: Sdk = tableSdk ?: run {
-            val moduleOrProject: ModuleOrProject = ModuleOrProject.ProjectOnly(project)
-
-            val result = createVenvAndSdk(
-                moduleOrProject = moduleOrProject,
-                explicitPath = sdkHome,
-            )
-
-            val newSdk = result.orThrow {
-                IllegalStateException(it.message)
+                registeredSdk?.let { it to false } ?: run {
+                    val newSdk = SdkConfigurationUtil.createSdk(
+                        sdkTable.allJdks.asList(),
+                        sdkHome,
+                        pythonSdkType,
+                        null,
+                        pythonSdkName,
+                    )
+                    val additionalData = pythonSdkType.loadAdditionalData(newSdk, Element("additional"))
+                    ApplicationManager.getApplication().runWriteAction {
+                        newSdk.sdkModificator.apply {
+                            sdkAdditionalData = additionalData
+                            commitChanges()
+                        }
+                    }
+                    pythonSdkType.setupSdkPaths(newSdk)
+                    SdkConfigurationUtil.addSdk(newSdk)
+                    newSdk to true
+                }
             }
+        }
 
-            edtWriteAction {
-                sdkTable.addJdk(newSdk)
-            }
+        if (created) {
             newPythonSdkNotif(project, pythonSdkName)
-            newSdk
         }
-
-        project.withModule(sdkConfig.module) {
-            setModuleSdk(it, sdk)
-        }
+        setModuleSdk(project, module, sdk)
     }
 
-    private fun setModuleSdk(module: Module, sdk: Sdk) {
-        if (module.pythonSdk?.name != sdk.name) {
-            ModuleRootModificationUtil.setModuleSdk(module, sdk)
+    private suspend fun setModuleSdk(project: Project, module: Module, sdk: Sdk) {
+        val (moduleSdkChanged, projectSdkChanged) = readAction {
+            val moduleSdkChanged = module.pythonSdk != sdk
+            val isProjectRootModule = project.basePath?.let { projectBasePath ->
+                ModuleRootManager.getInstance(module).contentRoots.any {
+                    FileUtil.pathsEqual(projectBasePath, it.path)
+                }
+            } == true
+            val projectSdkChanged = isProjectRootModule && project.pythonSdk != sdk
+            moduleSdkChanged to projectSdkChanged
+        }
+        edtWriteAction {
+            if (moduleSdkChanged) {
+                ModuleRootModificationUtil.setModuleSdk(module, sdk)
+            }
+            if (projectSdkChanged) {
+                ProjectRootManager.getInstance(project).projectSdk = sdk
+            }
+        }
+        if (moduleSdkChanged) {
             changedModulePythonSdkNotif(module, sdk.name)
         }
+    }
+}
+
+internal fun resolvePythonExecutable(configuredPath: Path): Path {
+    val normalizedPath = configuredPath.toAbsolutePath().normalize()
+    if (!normalizedPath.isDirectory()) return normalizedPath
+
+    return sequenceOf(normalizedPath, normalizedPath.resolve(".venv"))
+        .flatMap { environment ->
+            sequenceOf(
+                environment.resolve("bin/python"),
+                environment.resolve("bin/python3"),
+                environment.resolve("Scripts/python.exe"),
+            )
+        }
+        .firstOrNull(Path::isRegularFile)
+        ?: throw IllegalArgumentException("Python executable can not be found in: `$normalizedPath`")
+}
+
+internal fun findRegisteredPythonSdk(pythonExecutable: Path, sdks: Iterable<Sdk>): Sdk? {
+    val expectedPath = FileUtil.toCanonicalPath(pythonExecutable.toAbsolutePath().normalize().toString())
+    return sdks.firstOrNull { sdk ->
+        sdk.homePath?.let { FileUtil.pathsEqual(FileUtil.toCanonicalPath(it), expectedPath) } == true
     }
 }

--- a/src/test/kotlin/com/pswidersk/sdkimportplugin/SdkImportServiceTest.kt
+++ b/src/test/kotlin/com/pswidersk/sdkimportplugin/SdkImportServiceTest.kt
@@ -2,21 +2,32 @@ package com.pswidersk.sdkimportplugin
 
 import com.intellij.notification.Notification
 import com.intellij.notification.impl.NotificationsManagerImpl
+import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.project.stateStore
 import com.intellij.testFramework.junit5.RunMethodInEdt
 import com.intellij.testFramework.junit5.RunMethodInEdt.WriteIntentMode
 import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.fixture.moduleFixture
 import com.intellij.testFramework.junit5.fixture.projectFixture
+import com.intellij.testFramework.junit5.fixture.tempPathFixture
+import com.jetbrains.python.sdk.PythonSdkType
 import com.jetbrains.python.sdk.pythonSdk
+import com.pswidersk.sdkimportplugin.python.PythonSdkProcessor
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -25,13 +36,19 @@ private const val TEST_MODULE_NAME = "sample-python-module"
 @TestApplication
 class SdkImportServiceTest {
 
-    private val projectModel = projectFixture()
+    private val projectPathModel = tempPathFixture()
+    private val projectModel = projectFixture(projectPathModel)
     private val project: Project
         get() = projectModel.get()
 
     private val moduleModel = projectModel.moduleFixture(TEST_MODULE_NAME)
     private val module: Module
         get() = moduleModel.get()
+
+    private val nonProjectModulePathModel = tempPathFixture()
+    private val projectRootModuleModel = projectModel.moduleFixture(nonProjectModulePathModel, addPathToSourceRoot = true)
+    private val projectRootModule: Module
+        get() = projectRootModuleModel.get()
 
     private val ideaDir: File
         get() = project.stateStore.directoryStorePath!!.toFile().also { it.mkdir() }
@@ -48,20 +65,40 @@ class SdkImportServiceTest {
     private val jdkPath: String
         get() = System.getProperty("JDK_PATH")
 
-    @RunMethodInEdt(writeIntent = WriteIntentMode.True)
-    @Disabled("Disabled due to -> https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2070")
     @Test
-    fun `new Python SDK is imported`() {
-        // given
-        mockPythonSdk()
-        val projectService = project.service<SdkImportService>()
+    fun `existing Python SDK is registered once and assigned`() {
+        runBlocking {
+            val sdkConfig = SdkImportConfigEntry().apply {
+                type = PYTHON_SDK_TYPE
+                path = pythonPath
+                module = TEST_MODULE_NAME
+            }
+            val processor = PythonSdkProcessor(this)
+            edtWriteAction {
+                ModuleRootModificationUtil.addContentRoot(projectRootModule, projectPathModel.get().toString())
+            }
+            val contentRootPaths = readAction {
+                ModuleRootManager.getInstance(projectRootModule).contentRoots.map { it.toNioPath() }
+            }
+            assertThat(contentRootPaths).containsExactly(nonProjectModulePathModel.get(), projectPathModel.get())
 
-        // when
-        projectService.runImport()
+            coroutineScope {
+                listOf(module, projectRootModule).map { targetModule ->
+                    async { processor.addPythonSdk(project, targetModule, sdkConfig) }
+                }.awaitAll()
+            }
 
-        // then
-        assertThat(ProjectJdkTable.getInstance().allJdks).hasSize(1)
-        assertThat(module.pythonSdk?.name).isEqualTo("Python env: $pythonPath")
+            val registeredSdk = ProjectJdkTable.getInstance().allJdks.single()
+            assertThat(registeredSdk.homePath).isEqualTo(pythonPath)
+            assertThat(registeredSdk.sdkType).isSameAs(PythonSdkType.getInstance())
+            assertThat(module.pythonSdk).isSameAs(registeredSdk)
+            assertThat(projectRootModule.pythonSdk).isSameAs(registeredSdk)
+            assertThat(ProjectRootManager.getInstance(project).projectSdk).isSameAs(registeredSdk)
+
+            processor.addPythonSdk(project, projectRootModule, sdkConfig)
+
+            assertThat(ProjectJdkTable.getInstance().allJdks).containsExactly(registeredSdk)
+        }
     }
 
     @RunMethodInEdt(writeIntent = WriteIntentMode.True)
@@ -125,19 +162,6 @@ class SdkImportServiceTest {
         return testSdkImportConfig.import.first().path
     }
 
-    private fun mockPythonSdk() {
-        runWriteAction {
-            sdkImportFile.writeText(
-                """
-                import:
-                  - type: PYTHON
-                    path: $pythonPath
-                    module: $TEST_MODULE_NAME
-                """.trimIndent()
-            )
-        }
-    }
-
     private fun mockJdk() {
         runWriteAction {
             sdkImportFile.writeText(
@@ -160,4 +184,3 @@ class SdkImportServiceTest {
         }
     }
 }
-

--- a/src/test/kotlin/com/pswidersk/sdkimportplugin/python/PythonSdkProcessorTest.kt
+++ b/src/test/kotlin/com/pswidersk/sdkimportplugin/python/PythonSdkProcessorTest.kt
@@ -1,0 +1,102 @@
+package com.pswidersk.sdkimportplugin.python
+
+import com.intellij.openapi.projectRoots.Sdk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PythonSdkProcessorTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `direct interpreter path remains unchanged`() {
+        val python = Files.createFile(tempDir.resolve("python"))
+
+        assertThat(resolvePythonExecutable(python)).isEqualTo(python)
+    }
+
+    @Test
+    fun `virtualenv directory resolves its interpreter`() {
+        val python = createVirtualenv(tempDir.resolve("environment"))
+
+        assertThat(resolvePythonExecutable(python.parent.parent)).isEqualTo(python)
+    }
+
+    @Test
+    fun `virtualenv directory resolves a python3 interpreter`() {
+        val python = createUnixVirtualenv(tempDir.resolve("environment"), "python3")
+
+        assertThat(resolvePythonExecutable(tempDir.resolve("environment"))).isEqualTo(python)
+    }
+
+    @Test
+    fun `Windows virtualenv directory resolves its interpreter`() {
+        val python = createWindowsVirtualenv(tempDir.resolve("environment"))
+
+        assertThat(resolvePythonExecutable(tempDir.resolve("environment"))).isEqualTo(python)
+    }
+
+    @Test
+    fun `project directory resolves dot venv interpreter`() {
+        val python = createVirtualenv(tempDir.resolve("project/.venv"))
+
+        assertThat(resolvePythonExecutable(tempDir.resolve("project"))).isEqualTo(python)
+    }
+
+    @Test
+    fun `project directory resolves Windows dot venv interpreter`() {
+        val python = createWindowsVirtualenv(tempDir.resolve("project/.venv"))
+
+        assertThat(resolvePythonExecutable(tempDir.resolve("project"))).isEqualTo(python)
+    }
+
+    @Test
+    fun `virtualenv interpreter takes precedence over project dot venv`() {
+        val python = createVirtualenv(tempDir.resolve("project"))
+        createVirtualenv(tempDir.resolve("project/.venv"))
+
+        assertThat(resolvePythonExecutable(tempDir.resolve("project"))).isEqualTo(python)
+    }
+
+    @Test
+    fun `directory without an interpreter is rejected`() {
+        val directory = Files.createDirectory(tempDir.resolve("empty"))
+
+        assertThatThrownBy { resolvePythonExecutable(directory) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining(directory.toString())
+    }
+
+    @Test
+    fun `registered SDK is matched by interpreter path instead of name`() {
+        val python = Files.createDirectories(tempDir.resolve("environment/bin"))
+            .resolve("python")
+            .also(Files::createFile)
+        val sdk = mock<Sdk>()
+        `when`(sdk.name).thenReturn("IDE generated name")
+        `when`(sdk.homePath).thenReturn(python.toString())
+
+        assertThat(findRegisteredPythonSdk(python, listOf(sdk))).isSameAs(sdk)
+    }
+
+    private fun createVirtualenv(environment: Path): Path {
+        return createUnixVirtualenv(environment, "python")
+    }
+
+    private fun createUnixVirtualenv(environment: Path, executableName: String): Path {
+        val bin = Files.createDirectories(environment.resolve("bin"))
+        return Files.createFile(bin.resolve(executableName))
+    }
+
+    private fun createWindowsVirtualenv(environment: Path): Path {
+        val scripts = Files.createDirectories(environment.resolve("Scripts"))
+        return Files.createFile(scripts.resolve("python.exe"))
+    }
+}


### PR DESCRIPTION
## Summary

Fix Python SDK registration and assignment on IntelliJ Platform 2026.2 without relying on JetBrains internal APIs.

- Accept Python SDK paths pointing to an interpreter, virtualenv directory, or project directory containing `.venv`.
- Resolve Unix and Windows virtualenv interpreter layouts.
- Reuse registered Python SDKs by canonical interpreter path instead of generated SDK name.
- Register missing SDKs and initialize required Python metadata and paths through public IntelliJ Platform APIs.
- Assign the SDK to the configured module and, for project-root modules, to the project.
- Preserve cancellation and user-facing error handling while preventing duplicate registrations.
- Document the expanded Python path support and add a changelog entry.

## Testing

- Added unit coverage for direct paths, Unix and Windows virtualenvs, project-local `.venv`, interpreter precedence, invalid directories, and path-based SDK reuse.
- Added fixture coverage for concurrent registration, idempotent reuse, module assignment, and project assignment when the project root is not the module’s first content root.
- `./gradlew test verifyPlugin`
- Plugin Verifier result: compatible with IU 262.10315.69, with zero internal API usages.